### PR TITLE
Update esp_http_server Header length

### DIFF
--- a/components/esp_http_server/Kconfig
+++ b/components/esp_http_server/Kconfig
@@ -2,7 +2,7 @@ menu "HTTP Server"
 
     config HTTPD_MAX_REQ_HDR_LEN
         int "Max HTTP Request Header Length"
-        default 512
+        default 768
         help
             This sets the maximum supported size of headers section in HTTP request packet to be processed by the
             server


### PR DESCRIPTION
Initial value of max header length 512bytes -> 768bytes

For the following reasons, I propose raising the default value to prevent the code from becoming browser-dependent.

The Chrome browser (including Chromium Edge) may send long HTTP headers.
 - For example, when Chrome Developer Tools - Network - Disable cache was checked, longer than normal headers were sent.

And too long headers caused HTTP error 431 in the HTTP Server Module.
In my environment, the HTTP header size is usually around 500 bytes, which is close to the current initial limit (512 bytes).